### PR TITLE
Move from `React.createClass` to `create-react-class`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 var React = require('react');
 var stickyPosition = require('sticky-position');
+var createReactClass = require('create-react-class');
 
-module.exports = React.createClass({
+module.exports = createReactClass({
 	getDefaultProps: function() {
 		return {
 			className: 'sticky',

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "url": "http://github.com/jackmoore/react-sticky-position.git"
   },
   "dependencies": {
+    "create-react-class": "^15.6.0",
     "sticky-position": "^1.0.1"
   }
 }


### PR DESCRIPTION
`React.createClass` is deprecated in React 15.5.0 and will be removed in React 16. The function has been extracted to its own package: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.createclass

React developers now advises to use plain ES6 classes and no longer `createReactClass`. This would require a compilation step for compatibility and there is none for this module (which makes sense as it is tiny), so I preferred to use `create-react-class`.

String refs should also be changed, see https://facebook.github.io/react/docs/refs-and-the-dom.html#legacy-api-string-refs (but no deprecation yet). I can submit another PR for this if you want.